### PR TITLE
Limiting the delay to just under 5 seconds 

### DIFF
--- a/LogMonitor/src/LogMonitor/ProcessMonitor.cpp
+++ b/LogMonitor/src/LogMonitor/ProcessMonitor.cpp
@@ -200,16 +200,14 @@ std::mutex myWIPMutex;
 
 void WaitBeforeExit()
 {
-    int secs = 10;
+    int secs = 5;
     const std::lock_guard<std::mutex> lock(myWIPMutex);
     if ( ! waitInProgress ) {
         waitInProgress = true;
         logWriter.TraceInfo(
             Utility::FormatString(L"Waiting %d seconds after program exit.", secs).c_str()
         );
-        do {
-            Sleep(1000);
-        } while (secs-- > 0);
+        Sleep(secs*1000-100); // Secs - 100ms
         logWriter.TraceInfo(L"Done waiting after program exit.");
     }
 }

--- a/LogMonitor/src/LogMonitor/version.h
+++ b/LogMonitor/src/LogMonitor/version.h
@@ -8,9 +8,9 @@
 
 #define LM_MAJORNUMBER          1
 #define LM_MINORNUMBER          1
-#define LM_BUILDNUMBER          1
+#define LM_BUILDNUMBER          3
 #ifndef LM_BUILDMINORVERSION
-#define LM_BUILDMINORVERSION    0
+#define LM_BUILDMINORVERSION    129
 #endif
 
 #endif


### PR DESCRIPTION
To prevent LogMonitor from being forcefully terminated by a system timeout.